### PR TITLE
Format compatibilty to checkupdates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you need a fully-featured AUR helper, consider using [`paru`](https://github.
 | `--repos <names>`           | Override working repositories. By default all repositories from `dbpath/sync` directory are used. <sup>1</sup>                        |
 | `--endpoint <url>`          | Change AUR info endpoint url. Default value is `https://aur.archlinux.org/rpc/v5/info`.                                               |
 | `--timeout <ms>`            | Set a timeout for network connection in milliseconds. Default value is `5000`.                                                        |
+| `--raw`                     | Disable info messages, color and formatting.                                                                                          |
 | `-h`, `--help`              | Display the help message.                                                                                                             |
 
 1. Multiple values could be specified using a comma-separated list.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,6 +19,7 @@ pub struct Config {
     repos: Option<Arr<Str>>,
     endpoint: Option<Str>,
     timeout: Option<u64>,
+    raw: Option<bool>,
 }
 
 impl Config {
@@ -60,6 +61,10 @@ impl Config {
 
     pub fn timeout(&self) -> Option<u64> {
         self.timeout
+    }
+
+    pub fn raw(&self) -> Option<bool> {
+        self.raw
     }
 }
 
@@ -164,6 +169,9 @@ pub fn read_args(mut args: impl Iterator<Item = impl AsRef<str>>) -> Result<Opti
                     Ok(t) => t,
                     _ => E!(InvalidValue(F!(arg), F!(value))),
                 });
+            }
+            "--raw" => {
+                config.raw = Some(true);
             }
             "-h" | "--help" => return Ok(None),
             _ => E!(Unknown(F!(arg))),

--- a/src/help.in
+++ b/src/help.in
@@ -17,6 +17,7 @@ Options:
       [1m--repos <names>[0m              override working repositories [1]
       [1m--endpoint <url>[0m             change AUR info endpoint url
       [1m--timeout <ms>[0m               set a timeout for network connection in milliseconds
+      [1m--raw[0m                        disable info messages, color and formatting
   [1m-h[0m, [1m--help[0m                       display the help message
 
 1. Multiple values could be specified using a comma-separated list.

--- a/src/print.rs
+++ b/src/print.rs
@@ -77,8 +77,8 @@ pub fn update(
     };
 
     P!(
-        "{name:0$} {ver:1$} => {new_ver}",
-        "\x1b[0;1m{name:0$} \x1b[31;1m{ver:1$}\x1b[0m => {color}{new_ver}\x1b[0m",
+        "{name:0$} {ver:1$} -> {new_ver}",
+        "\x1b[0;1m{name:0$} \x1b[31;1m{ver:1$}\x1b[0m -> {color}{new_ver}\x1b[0m",
         nlen,
         vlen,
     );


### PR DESCRIPTION
* Replace `=>` with `->` in the update output.
* Implement new CLI option for raw output.

Closes #2.
